### PR TITLE
Webpack2

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,31 +9,43 @@ Loader to run [falafel](https://www.npmjs.com/package/falafel) AST transforms.
 
 This example fixes an [IE angular bug](https://github.com/angular/angular.js/issues/8659#issuecomment-60176967).
 
-Add it into the pipeline for a js file & add falafel config:
+Add it into webpack2 rules:
 
-    modules: {
-      falafel: function (node) {
-        if (node.type === 'FunctionExpression' && node.id && node.id.name === 'interpolateFnWatchAction') {
-          var expr = node && node.body && node.body.body && node.body.body[0];
+```JavaScript
+  ...
+  module: {
+    rules: [
+      ...
+        {
+          test: /angular\.js$/,
+          loader: 'falafel-loader',
+          options: {
+            fn: function (node) {
+              if (node.type === 'FunctionExpression' && node.id && node.id.name === 'interpolateFnWatchAction') {
+                var expr = node && node.body && node.body.body && node.body.body[0];
 
-          if (expr && expr.source() === 'node[0].nodeValue = value;') {
-            expr.update('if (!node[0].nodeValue) { return; } ' + expr.source());
+                if (expr && expr.source() === 'node[0].nodeValue = value;') {
+                  expr.update('if (!node[0].nodeValue) { return; } ' + expr.source());
+                }
+              }
+            },
+            // All of the opts will be passed directly to acorn by falafel.
+            opts: {
+              allowImportExportEverywhere: true
+            }
           }
         }
-      },
       ...
-      loaders: [
-        ...
-          {
-            test: /angular\.js$/,
-            loader: 'falafel-loader'
-          }
-        ...
-      ]
-      ...
-    }
+    ]
+  }
+  ...
+```
 
 This will rewrite the `interpolateFnWatchAction` with the necessary null check. You can implement any falafel function that you want, however.
+
+## Webpack 1
+
+This loader works with webpack 2, for webpack 1, please use v0.0.3
 
 ## TODO
 

--- a/index.js
+++ b/index.js
@@ -3,9 +3,11 @@
 var falafel = require('falafel');
 
 module.exports = function (source) {
-  this.cacheable();
-  var fn = this.options && this.options.falafel || function () {};
-  var output = falafel(source, fn);
+  this.cacheable(false);
+  var options = this.loaders[this.loaderIndex].options;
+  var fn = options && options.fn || function () {};
+  var opts = options && options.opts || {};
+  var output = falafel(source, opts, fn);
 
   return output.toString();
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "falafel-loader",
-  "version": "0.0.3",
+  "version": "1.0.0",
   "description": "Run a falafel AST transform as a webpack-loader",
   "main": "index.js",
   "scripts": {
@@ -25,6 +25,6 @@
   },
   "homepage": "https://github.com/wombleton/falafel-loader#readme",
   "dependencies": {
-    "falafel": "^1.2.0"
+    "falafel": "^2.0.0"
   }
 }


### PR DESCRIPTION
Hi @wombleton!
I've been using your falafel-loader for webpack, thanks for it!

This PR updates it to work with webpack2 now that it has been [officially released](https://github.com/webpack/webpack/releases/tag/v2.2.0).

- [x] Updated to latest falafel 2.0.0
- [x] [cacheable by default](https://webpack.js.org/guides/migrating/#cacheable) with opt-out option
- [x] Added possibility to pass an [optionHash](https://github.com/substack/node-falafel#falafelsrc-opts-fn) to Falafel (Falafel pass it directly to acorn)
- [x] Updated documentation accordingly

Let me know what you think? Would be nice if you could merge this and publish so that there is no need for maintaining a fork. Also if you like feel free to add me to the project and/or npm if you need any help with maintaining it.

